### PR TITLE
群聊语音支持概率回复并导出转写上下文

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@
 - 🔁 转写结果自动转发给 AstrBot 框架（`request_llm`）
 - 🧠 可与框架现有人格、记忆系统协作
 - 🧩 支持群聊开关与群白名单
+- 🎚️ 支持群聊语音“都识别但仅概率回复”
+- 🧭 支持向 contextaware 导出语音转写上下文
 - ⚙️ 支持失败策略可配置（放行/拦截/提示）
 - 📝 支持输出模式：
   - `simple`：仅原话转写
@@ -106,6 +108,21 @@ request_llm 在复杂 hook 链中的稳定放行策略
 simple 模式原话提取的鲁棒性
 
 语音输入与文本输入的体验一致性优化
+
+## 🧩 群聊概率回复与兼容建议
+
+群聊语音通常就是单独的 `Record` 消息，不能可靠携带 @、引用回复或文字唤醒词。因此推荐把“识别”和“回复”拆开：
+
+```yaml
+enable_group_voice: true
+group_voice_reply_probability: 0.1
+group_voice_export_context: true
+```
+
+- `group_voice_reply_probability=1`：保持旧行为，所有群语音识别后都会进入框架 LLM 回复链路。
+- `group_voice_reply_probability=0.1`：所有群语音都会识别，但只有约 10% 会进入框架 LLM 回复链路。
+- `group_voice_reply_probability=0`：只识别并导出上下文，不主动回复。
+- `group_voice_export_context=true`：把识别结果写入事件 extra，供 contextaware 记录为 `[语音转写] ...`。
 
 欢迎提交 Issue / PR
 ---

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -42,6 +42,20 @@
     "hint": "群号字符串列表；留空表示不限制。示例: [\"123456\", \"789012\"]",
     "default": []
   },
+  "group_voice_reply_probability": {
+    "description": "群聊语音回复概率",
+    "type": "float",
+    "hint": "范围 0~1。1=旧行为，每条群语音识别后都回复；0=只识别并写入上下文，不主动回复；0.1=约 10% 群语音进入 LLM 回复链路",
+    "default": 1.0,
+    "min": 0,
+    "max": 1
+  },
+  "group_voice_export_context": {
+    "description": "导出群语音转写上下文",
+    "type": "bool",
+    "hint": "开启后会把转写结果写入事件 extra，供 contextaware 等插件记录上下文；建议保持开启",
+    "default": true
+  },
   "stop_other_handlers": {
     "description": "是否阻止后续插件继续处理原语音事件",
     "type": "bool",

--- a/main.py
+++ b/main.py
@@ -78,7 +78,7 @@ class StaticResolver(AbstractResolver):
         return
 
 
-@register("Gemini_STT", "政ひかりはる", "Gemini语音转写桥接到框架LLM", "2.4.1")
+@register("Gemini_STT", "政ひかりはる", "Gemini语音转写桥接到框架LLM", "2.4.2")
 class GeminiSTTBridge(Star):
     def __init__(self, context: Context, config: AstrBotConfig = None):
         super().__init__(context)
@@ -167,7 +167,7 @@ class GeminiSTTBridge(Star):
         self._cleanup_bootstrapped = False
         self._cleanup_prefixes = ("gsv_", "gsv_url_", "gsv_record_")
 
-        logger.info("[GeminiSTTBridge] 插件已加载 v2.4.1")
+        logger.info("[GeminiSTTBridge] 插件已加载 v2.4.2")
         logger.info(
             f"[GeminiSTTBridge] enable_voice={self.enable_voice}, output_mode={self.output_mode}, "
             f"fail={self.on_stt_fail}, stop={self.stop_event_timing}/{self.stop_other_handlers}, "
@@ -498,6 +498,36 @@ class GeminiSTTBridge(Star):
                 return out
 
         return t
+
+    def _is_provider_error_text(self, stt_text: str) -> bool:
+        """
+        兼容部分代理把供应商错误包装成 200 + text 的情况，避免把错误提示当语音转写写入上下文。
+        """
+        t = re.sub(r"\s+", " ", (stt_text or "").strip())
+        if not t:
+            return False
+
+        lowered = t.lower()
+        exact_markers = (
+            "is no longer available. please switch",
+            "please switch to a supported model",
+            "not found for api version",
+            "api key not valid",
+            "permission denied",
+            "quota exceeded",
+            "resource exhausted",
+        )
+        if any(marker in lowered for marker in exact_markers):
+            return True
+
+        if re.search(
+            r"\b(?:gemini|model|models/)[\w\s./:-]{0,120}"
+            r"(?:deprecated|not available|not found|unsupported|not supported|does not exist)\b",
+            lowered,
+        ):
+            return True
+
+        return bool(re.search(r'^\s*\{.*"error"\s*:', stt_text or "", flags=re.DOTALL))
 
     def _file_size_ok(self, size_bytes: int) -> bool:
         return size_bytes <= self.max_audio_mb * 1024 * 1024
@@ -1207,6 +1237,10 @@ class GeminiSTTBridge(Star):
                             self._d(f"Gemini返回非JSON: {raw[:200]}")
                             return ""
 
+                        if isinstance(data, dict) and data.get("error"):
+                            self._d(f"Gemini返回错误对象: {str(data.get('error'))[:300]}")
+                            return ""
+
                         cands = data.get("candidates", [])
                         if not cands:
                             self._d("Gemini返回空candidates")
@@ -1216,7 +1250,11 @@ class GeminiSTTBridge(Star):
                         for p in parts:
                             text = p.get("text")
                             if text and text.strip():
-                                return text.strip()
+                                text = text.strip()
+                                if self._is_provider_error_text(text):
+                                    self._d(f"Gemini返回供应商错误文本: {text[:300]}")
+                                    return ""
+                                return text
 
                         self._d("Gemini返回parts中无text")
                         return ""
@@ -1444,6 +1482,12 @@ class GeminiSTTBridge(Star):
             stt_text = self._clean_transcript(stt_text)
 
             if not stt_text:
+                async for r in self._handle_stt_fail(event):
+                    yield r
+                return
+
+            if self._is_provider_error_text(stt_text):
+                logger.warning(f"[GeminiSTTBridge] 识别返回供应商错误文本，按失败处理: {stt_text[:200]}")
                 async for r in self._handle_stt_fail(event):
                     yield r
                 return

--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ import aiohttp
 from aiohttp.abc import AbstractResolver
 
 from astrbot.api.event import filter, AstrMessageEvent
+from astrbot.api.message_components import Plain
 from astrbot.api.star import Context, Star, register
 from astrbot.api import AstrBotConfig, logger
 
@@ -42,6 +43,7 @@ EXTRA_STT_IS_GROUP = "_gemini_stt_is_group"
 EXTRA_STT_SHOULD_REPLY = "_gemini_stt_should_reply"
 EXTRA_STT_REPLY_REASON = "_gemini_stt_reply_reason"
 EXTRA_STT_CACHE_ONLY = "_gemini_stt_cache_only"
+VOICE_CONTEXT_PREFIX = "[语音转写] "
 
 
 class StaticResolver(AbstractResolver):
@@ -76,7 +78,7 @@ class StaticResolver(AbstractResolver):
         return
 
 
-@register("Gemini_STT", "政ひかりはる", "Gemini语音转写桥接到框架LLM", "2.4.0")
+@register("Gemini_STT", "政ひかりはる", "Gemini语音转写桥接到框架LLM", "2.4.1")
 class GeminiSTTBridge(Star):
     def __init__(self, context: Context, config: AstrBotConfig = None):
         super().__init__(context)
@@ -165,7 +167,7 @@ class GeminiSTTBridge(Star):
         self._cleanup_bootstrapped = False
         self._cleanup_prefixes = ("gsv_", "gsv_url_", "gsv_record_")
 
-        logger.info("[GeminiSTTBridge] 插件已加载 v2.4.0")
+        logger.info("[GeminiSTTBridge] 插件已加载 v2.4.1")
         logger.info(
             f"[GeminiSTTBridge] enable_voice={self.enable_voice}, output_mode={self.output_mode}, "
             f"fail={self.on_stt_fail}, stop={self.stop_event_timing}/{self.stop_other_handlers}, "
@@ -202,6 +204,23 @@ class GeminiSTTBridge(Star):
             setter(key, value)
         except Exception as e:
             self._d(f"写入事件 extra 失败: {key}, err={e}")
+
+    def _inject_transcript_plain(self, event: AstrMessageEvent, final_text: str) -> None:
+        """把转写结果补进消息链，供后续普通消息监听器记录上下文。"""
+        text = self._clean_transcript(final_text)
+        if not text:
+            return
+
+        context_text = f"{VOICE_CONTEXT_PREFIX}{text}"
+        try:
+            messages = self._get_messages(event)
+            if isinstance(messages, list):
+                for comp in messages:
+                    if type(comp).__name__ == "Plain" and getattr(comp, "text", "") == context_text:
+                        return
+                messages.insert(0, Plain(context_text))
+        except Exception as e:
+            self._d(f"写入语音转写消息链失败: {e}")
 
     def _normalize_allowed_dirs(self, raw_dirs: List[str]) -> List[str]:
         out = []
@@ -1456,6 +1475,7 @@ class GeminiSTTBridge(Star):
                 should_reply=should_reply,
                 reply_reason=reply_reason,
             )
+            self._inject_transcript_plain(event, final_text)
 
             if not should_reply:
                 self._d(f"群聊语音已识别但不触发回复: reason={reply_reason}, text={final_text[:80]}")

--- a/main.py
+++ b/main.py
@@ -35,6 +35,15 @@ except ImportError:
     PILK_AVAILABLE = False
 
 
+EXTRA_STT_TRANSCRIPT = "_gemini_stt_transcript"
+EXTRA_STT_RAW_TEXT = "_gemini_stt_raw_text"
+EXTRA_STT_FORWARD_TEXT = "_gemini_stt_forward_text"
+EXTRA_STT_IS_GROUP = "_gemini_stt_is_group"
+EXTRA_STT_SHOULD_REPLY = "_gemini_stt_should_reply"
+EXTRA_STT_REPLY_REASON = "_gemini_stt_reply_reason"
+EXTRA_STT_CACHE_ONLY = "_gemini_stt_cache_only"
+
+
 class StaticResolver(AbstractResolver):
     """
     将 host 固定解析到预先校验过的 IP 列表，缓解 DNS rebinding / TOCTOU。
@@ -67,7 +76,7 @@ class StaticResolver(AbstractResolver):
         return
 
 
-@register("Gemini_STT", "政ひかりはる", "Gemini语音转写桥接到框架LLM", "2.3.6")
+@register("Gemini_STT", "政ひかりはる", "Gemini语音转写桥接到框架LLM", "2.4.0")
 class GeminiSTTBridge(Star):
     def __init__(self, context: Context, config: AstrBotConfig = None):
         super().__init__(context)
@@ -81,6 +90,10 @@ class GeminiSTTBridge(Star):
         # 群聊
         self.enable_group_voice = bool(self._cfg("enable_group_voice", False))
         self.group_voice_whitelist = [str(g) for g in self._cfg("group_voice_whitelist", [])]
+        self.group_voice_reply_probability = self._clamp_probability(
+            self._cfg("group_voice_reply_probability", 1.0)
+        )
+        self.group_voice_export_context = bool(self._cfg("group_voice_export_context", True))
 
         # 行为策略
         self.stop_other_handlers = bool(self._cfg("stop_other_handlers", False))
@@ -152,10 +165,11 @@ class GeminiSTTBridge(Star):
         self._cleanup_bootstrapped = False
         self._cleanup_prefixes = ("gsv_", "gsv_url_", "gsv_record_")
 
-        logger.info("[GeminiSTTBridge] 插件已加载 v2.3.6")
+        logger.info("[GeminiSTTBridge] 插件已加载 v2.4.0")
         logger.info(
             f"[GeminiSTTBridge] enable_voice={self.enable_voice}, output_mode={self.output_mode}, "
-            f"fail={self.on_stt_fail}, stop={self.stop_event_timing}/{self.stop_other_handlers}"
+            f"fail={self.on_stt_fail}, stop={self.stop_event_timing}/{self.stop_other_handlers}, "
+            f"group_reply_probability={self.group_voice_reply_probability}"
         )
         logger.info(
             f"[GeminiSTTBridge] ffmpeg={'✓' if self.ffmpeg_path else '✗'}, pilk={'✓' if PILK_AVAILABLE else '✗'}"
@@ -172,6 +186,22 @@ class GeminiSTTBridge(Star):
     def _d(self, msg: str):
         if self.debug:
             logger.info(f"[GeminiSTTBridge] {msg}")
+
+    def _clamp_probability(self, value) -> float:
+        try:
+            probability = float(value)
+        except (TypeError, ValueError):
+            probability = 1.0
+        return max(0.0, min(1.0, probability))
+
+    def _set_event_extra(self, event: AstrMessageEvent, key: str, value) -> None:
+        setter = getattr(event, "set_extra", None)
+        if not callable(setter):
+            return
+        try:
+            setter(key, value)
+        except Exception as e:
+            self._d(f"写入事件 extra 失败: {key}, err={e}")
 
     def _normalize_allowed_dirs(self, raw_dirs: List[str]) -> List[str]:
         out = []
@@ -497,7 +527,9 @@ class GeminiSTTBridge(Star):
                 return False
         return True
 
-    def _should_stop_before_stt(self) -> bool:
+    def _should_stop_before_stt(self, event: AstrMessageEvent) -> bool:
+        if self._is_group_message(event) and self.group_voice_reply_probability < 1.0:
+            return False
         return (
             self.stop_other_handlers
             and self.stop_event_timing == "before_stt"
@@ -1328,6 +1360,41 @@ class GeminiSTTBridge(Star):
             return self._clean_transcript(plain)
         return self._clean_transcript(stt_text)
 
+    def _should_reply_to_voice(self, event: AstrMessageEvent) -> Tuple[bool, str]:
+        if not self._is_group_message(event):
+            return True, "private_voice"
+
+        probability = self.group_voice_reply_probability
+        if probability <= 0:
+            return False, "group_probability_miss"
+        if probability >= 1:
+            return True, "group_probability_hit"
+
+        if random.random() < probability:
+            return True, "group_probability_hit"
+        return False, "group_probability_miss"
+
+    def _export_stt_context(
+        self,
+        event: AstrMessageEvent,
+        *,
+        stt_text: str,
+        final_text: str,
+        forward_text: str,
+        should_reply: bool,
+        reply_reason: str,
+    ) -> None:
+        if not self.group_voice_export_context:
+            return
+        is_group = self._is_group_message(event)
+        self._set_event_extra(event, EXTRA_STT_TRANSCRIPT, final_text)
+        self._set_event_extra(event, EXTRA_STT_RAW_TEXT, stt_text)
+        self._set_event_extra(event, EXTRA_STT_FORWARD_TEXT, forward_text)
+        self._set_event_extra(event, EXTRA_STT_IS_GROUP, is_group)
+        self._set_event_extra(event, EXTRA_STT_SHOULD_REPLY, should_reply)
+        self._set_event_extra(event, EXTRA_STT_REPLY_REASON, reply_reason)
+        self._set_event_extra(event, EXTRA_STT_CACHE_ONLY, is_group and not should_reply)
+
     # ---------------- 事件入口 ----------------
 
     @filter.event_message_type(filter.EventMessageType.ALL, priority=1)
@@ -1345,7 +1412,7 @@ class GeminiSTTBridge(Star):
             if not self._should_process_voice(event):
                 return
 
-            if self._should_stop_before_stt():
+            if self._should_stop_before_stt(event):
                 event.stop_event()
 
             audio_b64, audio_mime = await self._get_voice_data(event, voice_comp)
@@ -1376,13 +1443,27 @@ class GeminiSTTBridge(Star):
                     yield r
                 return
 
-            if self._should_stop_after_stt_success():
-                event.stop_event()
-
             if self.show_transcript:
                 yield event.plain_result(f"📝 识别结果：{final_text}")
 
             forward_text = self._build_forward_text(event, final_text)
+            should_reply, reply_reason = self._should_reply_to_voice(event)
+            self._export_stt_context(
+                event,
+                stt_text=stt_text,
+                final_text=final_text,
+                forward_text=forward_text,
+                should_reply=should_reply,
+                reply_reason=reply_reason,
+            )
+
+            if not should_reply:
+                self._d(f"群聊语音已识别但不触发回复: reason={reply_reason}, text={final_text[:80]}")
+                return
+
+            if self._should_stop_after_stt_success():
+                event.stop_event()
+
             self._d(f"output_mode={self.output_mode}, final_len={len(final_text)}")
             self._d(f"forward_preview={forward_text[:220]}")
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 name: "astrbot_plugin_Gemini_STT"
 author: "政ひかりはる"
 description: "使用Gemini模型来实现STT(分析特别详细哦)"
-version: "2.3.6"
+version: "2.4.0"
 repo: "https://github.com/Weather-719/astrbot_plugin_Gemini_STT"
 tags: ["AstrBot", "语音", "STT", "Gemini", "桥接"]
 license: "MIT"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 name: "astrbot_plugin_Gemini_STT"
 author: "政ひかりはる"
 description: "使用Gemini模型来实现STT(分析特别详细哦)"
-version: "2.4.0"
+version: "2.4.1"
 repo: "https://github.com/Weather-719/astrbot_plugin_Gemini_STT"
 tags: ["AstrBot", "语音", "STT", "Gemini", "桥接"]
 license: "MIT"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 name: "astrbot_plugin_Gemini_STT"
 author: "政ひかりはる"
 description: "使用Gemini模型来实现STT(分析特别详细哦)"
-version: "2.4.1"
+version: "2.4.2"
 repo: "https://github.com/Weather-719/astrbot_plugin_Gemini_STT"
 tags: ["AstrBot", "语音", "STT", "Gemini", "桥接"]
 license: "MIT"

--- a/tests/test_group_voice_gate.py
+++ b/tests/test_group_voice_gate.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+PLUGIN_PATH = Path(__file__).resolve().parents[1] / "main.py"
+
+
+def _decorator(*args: Any, **kwargs: Any):
+    def wrap(func):
+        return func
+
+    return wrap
+
+
+def install_astrbot_stubs() -> dict[str, types.ModuleType]:
+    astrbot_mod = types.ModuleType("astrbot")
+    api_mod = types.ModuleType("astrbot.api")
+    event_mod = types.ModuleType("astrbot.api.event")
+    star_mod = types.ModuleType("astrbot.api.star")
+
+    class Logger:
+        def info(self, *args, **kwargs):
+            pass
+
+        def warning(self, *args, **kwargs):
+            pass
+
+        def error(self, *args, **kwargs):
+            pass
+
+    class Star:
+        def __init__(self, context):
+            self.context = context
+
+    def register(*args, **kwargs):
+        return _decorator(*args, **kwargs)
+
+    class EventMessageType:
+        ALL = object()
+
+    FilterNamespace = types.SimpleNamespace(
+        EventMessageType=EventMessageType,
+        event_message_type=_decorator,
+    )
+
+    event_mod.AstrMessageEvent = object
+    event_mod.filter = FilterNamespace
+    star_mod.Context = object
+    star_mod.Star = Star
+    star_mod.register = register
+    api_mod.AstrBotConfig = dict
+    api_mod.logger = Logger()
+
+    return {
+        "astrbot": astrbot_mod,
+        "astrbot.api": api_mod,
+        "astrbot.api.event": event_mod,
+        "astrbot.api.star": star_mod,
+    }
+
+
+def load_plugin_module():
+    with patch.dict(sys.modules, install_astrbot_stubs()):
+        spec = importlib.util.spec_from_file_location("gemini_stt_main", PLUGIN_PATH)
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        sys.modules["gemini_stt_main"] = module
+        spec.loader.exec_module(module)
+        sys.modules.pop("gemini_stt_main", None)
+        return module
+
+
+class FakeContext:
+    pass
+
+
+class FakeEvent:
+    def __init__(self, group_id: str = "200"):
+        self._group_id = group_id
+        self.extras: dict[str, Any] = {}
+        self.requested_llm = False
+
+    def get_group_id(self):
+        return self._group_id
+
+    def set_extra(self, key, value):
+        self.extras[key] = value
+
+    def request_llm(self, **kwargs):
+        self.requested_llm = True
+        return {"request_llm": kwargs}
+
+
+class GeminiSTTGroupGateTest(unittest.TestCase):
+    def setUp(self):
+        self.mod = load_plugin_module()
+
+    def make_plugin(self, config: dict[str, Any] | None = None):
+        plugin = self.mod.GeminiSTTBridge(FakeContext(), config or {})
+        plugin.ffmpeg_path = ""
+        return plugin
+
+    def test_probability_zero_group_voice_does_not_reply(self):
+        plugin = self.make_plugin(
+            {
+                "enable_group_voice": True,
+                "group_voice_reply_probability": 0,
+            }
+        )
+        event = FakeEvent()
+
+        should_reply, reason = plugin._should_reply_to_voice(event)
+
+        self.assertFalse(should_reply)
+        self.assertEqual(reason, "group_probability_miss")
+
+    def test_private_voice_always_replies_even_with_probability_zero(self):
+        plugin = self.make_plugin(
+            {
+                "group_voice_reply_probability": 0,
+            }
+        )
+        event = FakeEvent(group_id="")
+
+        should_reply, reason = plugin._should_reply_to_voice(event)
+
+        self.assertTrue(should_reply)
+        self.assertEqual(reason, "private_voice")
+
+    def test_export_stt_context_sets_contextaware_extras(self):
+        plugin = self.make_plugin()
+        event = FakeEvent()
+
+        plugin._export_stt_context(
+            event,
+            stt_text="raw text",
+            final_text="hello",
+            forward_text="forward",
+            should_reply=False,
+            reply_reason="group_probability_miss",
+        )
+
+        self.assertEqual(event.extras[self.mod.EXTRA_STT_TRANSCRIPT], "hello")
+        self.assertEqual(event.extras[self.mod.EXTRA_STT_RAW_TEXT], "raw text")
+        self.assertEqual(event.extras[self.mod.EXTRA_STT_FORWARD_TEXT], "forward")
+        self.assertTrue(event.extras[self.mod.EXTRA_STT_IS_GROUP])
+        self.assertFalse(event.extras[self.mod.EXTRA_STT_SHOULD_REPLY])
+        self.assertTrue(event.extras[self.mod.EXTRA_STT_CACHE_ONLY])
+
+    def test_probability_group_voice_does_not_stop_before_stt(self):
+        plugin = self.make_plugin(
+            {
+                "enable_group_voice": True,
+                "group_voice_reply_probability": 0,
+                "stop_other_handlers": True,
+                "stop_event_timing": "before_stt",
+                "on_stt_fail": "block",
+            }
+        )
+        event = FakeEvent()
+
+        self.assertFalse(plugin._should_stop_before_stt(event))
+
+    def test_probability_one_group_voice_replies(self):
+        plugin = self.make_plugin(
+            {
+                "enable_group_voice": True,
+                "group_voice_reply_probability": 1,
+            }
+        )
+        event = FakeEvent()
+
+        should_reply, reason = plugin._should_reply_to_voice(event)
+
+        self.assertTrue(should_reply)
+        self.assertEqual(reason, "group_probability_hit")
+
+    def test_probability_one_group_voice_keeps_old_stop_before_stt_behavior(self):
+        plugin = self.make_plugin(
+            {
+                "enable_group_voice": True,
+                "group_voice_reply_probability": 1,
+                "stop_other_handlers": True,
+                "stop_event_timing": "before_stt",
+                "on_stt_fail": "block",
+            }
+        )
+        event = FakeEvent()
+
+        self.assertTrue(plugin._should_stop_before_stt(event))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_group_voice_gate.py
+++ b/tests/test_group_voice_gate.py
@@ -23,6 +23,7 @@ def install_astrbot_stubs() -> dict[str, types.ModuleType]:
     api_mod = types.ModuleType("astrbot.api")
     event_mod = types.ModuleType("astrbot.api.event")
     star_mod = types.ModuleType("astrbot.api.star")
+    message_components_mod = types.ModuleType("astrbot.api.message_components")
 
     class Logger:
         def info(self, *args, **kwargs):
@@ -44,6 +45,10 @@ def install_astrbot_stubs() -> dict[str, types.ModuleType]:
     class EventMessageType:
         ALL = object()
 
+    class Plain:
+        def __init__(self, text: str, **kwargs):
+            self.text = text
+
     FilterNamespace = types.SimpleNamespace(
         EventMessageType=EventMessageType,
         event_message_type=_decorator,
@@ -54,6 +59,7 @@ def install_astrbot_stubs() -> dict[str, types.ModuleType]:
     star_mod.Context = object
     star_mod.Star = Star
     star_mod.register = register
+    message_components_mod.Plain = Plain
     api_mod.AstrBotConfig = dict
     api_mod.logger = Logger()
 
@@ -61,6 +67,7 @@ def install_astrbot_stubs() -> dict[str, types.ModuleType]:
         "astrbot": astrbot_mod,
         "astrbot.api": api_mod,
         "astrbot.api.event": event_mod,
+        "astrbot.api.message_components": message_components_mod,
         "astrbot.api.star": star_mod,
     }
 
@@ -85,12 +92,16 @@ class FakeEvent:
         self._group_id = group_id
         self.extras: dict[str, Any] = {}
         self.requested_llm = False
+        self.messages: list[Any] = []
 
     def get_group_id(self):
         return self._group_id
 
     def set_extra(self, key, value):
         self.extras[key] = value
+
+    def get_messages(self):
+        return self.messages
 
     def request_llm(self, **kwargs):
         self.requested_llm = True
@@ -152,6 +163,25 @@ class GeminiSTTGroupGateTest(unittest.TestCase):
         self.assertTrue(event.extras[self.mod.EXTRA_STT_IS_GROUP])
         self.assertFalse(event.extras[self.mod.EXTRA_STT_SHOULD_REPLY])
         self.assertTrue(event.extras[self.mod.EXTRA_STT_CACHE_ONLY])
+
+    def test_inject_transcript_plain_adds_context_message(self):
+        plugin = self.make_plugin()
+        event = FakeEvent()
+
+        plugin._inject_transcript_plain(event, "吱吱听得到吗？")
+
+        self.assertEqual(len(event.messages), 1)
+        self.assertEqual(event.messages[0].text, "[语音转写] 吱吱听得到吗？")
+        self.assertFalse(event.requested_llm)
+
+    def test_inject_transcript_plain_is_idempotent(self):
+        plugin = self.make_plugin()
+        event = FakeEvent()
+
+        plugin._inject_transcript_plain(event, "吱吱听得到吗？")
+        plugin._inject_transcript_plain(event, "吱吱听得到吗？")
+
+        self.assertEqual(len(event.messages), 1)
 
     def test_probability_group_voice_does_not_stop_before_stt(self):
         plugin = self.make_plugin(

--- a/tests/test_group_voice_gate.py
+++ b/tests/test_group_voice_gate.py
@@ -183,6 +183,21 @@ class GeminiSTTGroupGateTest(unittest.TestCase):
 
         self.assertEqual(len(event.messages), 1)
 
+    def test_provider_error_text_is_not_valid_transcript(self):
+        plugin = self.make_plugin()
+
+        self.assertTrue(
+            plugin._is_provider_error_text(
+                "Gemini 3 Pro is no longer available. Please switch to a supported model."
+            )
+        )
+        self.assertTrue(
+            plugin._is_provider_error_text(
+                '{"error": {"message": "models/gemini-pro is not found for API version v1beta"}}'
+            )
+        )
+        self.assertFalse(plugin._is_provider_error_text("1) 原话转写：我是怎么唱的呀"))
+
     def test_probability_group_voice_does_not_stop_before_stt(self):
         plugin = self.make_plugin(
             {


### PR DESCRIPTION
## 这次改了什么

这个 PR 解决群聊语音太容易触发机器人回复的问题。以前群里只要有人发语音, 插件识别完就会直接让机器人回复; 私聊这样没问题, 但群聊里会显得机器人太吵。

现在群聊语音会拆成两步:

- 语音照常识别, 不会因为本次不回复就跳过 STT。
- 是否让机器人回复, 由 `group_voice_reply_probability` 控制。

## 配置效果

- `group_voice_reply_probability: 1.0`: 保持旧行为, 群语音识别后都回复。
- `group_voice_reply_probability: 0.1`: 所有群语音都识别, 但大约只有 10% 会触发回复。
- `group_voice_reply_probability: 0`: 只识别并导出上下文, 不主动回复。

私聊语音不受这个概率影响, 仍然识别后正常回复。

## 兼容 contextaware

识别结果会写入 event extra, contextaware 这类上下文插件可以把语音内容记录成 `[语音转写] ...`。这样即使这条群语音没有触发机器人回复, 后续对话也能看到它的转写内容。

## 额外保护

补了一个防污染保护: 如果上游 Gemini 或代理把“模型不可用 / API 错误”包装成普通文本返回, 插件不会再把这类错误当成语音转写写进上下文, 而是按 STT 失败处理。

## 测试

- `python3 -m py_compile main.py tests/test_group_voice_gate.py`
- `python3 -m unittest tests.test_group_voice_gate`
